### PR TITLE
Set the admin nav tree for users that have site config capability

### DIFF
--- a/pages/pages.php
+++ b/pages/pages.php
@@ -61,6 +61,12 @@ $PAGE->set_title(get_string('pagesetup_title', 'local_pages'));
 $PAGE->set_heading(get_string('pagesetup_heading', 'local_pages'));
 $PAGE->requires->jquery();
 
+// Set the admin navigation tree to Plugins > Local Plugins > Pages > Manage Pages for users that have site config.
+if (has_capability('moodle/site:config', $context)) {
+    require_once($CFG->libdir . '/adminlib.php');
+    admin_externalpage_setup('Manage Pages');
+}
+
 echo $OUTPUT->header();
 
 printf('<h1 class="page__title">%s</h1>', get_string('custompage_title', 'local_pages'));


### PR DESCRIPTION
For users that have moodle/site:config capability, set the admin nav tree

With change.
![screen shot 2018-02-14 at 2 10 03 pm](https://user-images.githubusercontent.com/14080126/36182925-d103b0d0-1190-11e8-8933-b802d7c49220.png)

Without change.
![screen shot 2018-02-14 at 2 11 35 pm](https://user-images.githubusercontent.com/14080126/36182970-0bd1bc3e-1191-11e8-80ee-9de8a4cb2362.png)

