### PR TITLE
Fix issue with inconsistent error property name

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -39,7 +39,7 @@ class local_pages_renderer extends plugin_renderer_base {
     /**
      * @var array
      */
-    public $errorfields = array();
+    public $error_fields = array();
 
     /**
      *


### PR DESCRIPTION
The error messages on forms weren't displaying, because the code to access was using $this->error_fields instead of $this->errorfields. Changing the property definition was the least amount of change (instead of changing all the lines that access it).